### PR TITLE
Add sales statistics section

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,12 +21,35 @@
             max-width: 800px;
             margin: 2rem auto;
             padding: 0 1rem;
+            margin-bottom: 100px;
         }
         section {
             background-color: #f8f9fa;
             border-radius: 8px;
             padding: 2rem;
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            margin-bottom: 2rem;
+        }
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 1rem;
+            margin-top: 1rem;
+        }
+        .stat-card {
+            background-color: white;
+            padding: 1rem;
+            border-radius: 4px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+        }
+        .stat-card h3 {
+            margin: 0 0 0.5rem 0;
+            color: #2c3e50;
+        }
+        .stat-value {
+            font-size: 1.5rem;
+            font-weight: bold;
+            color: #2980b9;
         }
         footer {
             background-color: #2c3e50;
@@ -47,6 +70,27 @@
         <section>
             <h2>Welcome to our Book Sales Tracker</h2>
             <p>Track your book sales and profits in real-time.</p>
+        </section>
+        <section>
+            <h2>Sales Statistics</h2>
+            <div class="stats-grid">
+                <div class="stat-card">
+                    <h3>Monthly Revenue</h3>
+                    <div class="stat-value">$12,450</div>
+                </div>
+                <div class="stat-card">
+                    <h3>Best Seller</h3>
+                    <div class="stat-value">The Great Adventure</div>
+                </div>
+                <div class="stat-card">
+                    <h3>Profit Margin</h3>
+                    <div class="stat-value">32%</div>
+                </div>
+                <div class="stat-card">
+                    <h3>Monthly Growth</h3>
+                    <div class="stat-value">+15%</div>
+                </div>
+            </div>
         </section>
     </main>
     <footer>


### PR DESCRIPTION
This PR adds a new sales statistics section to the dashboard with:

- Monthly revenue display
- Best-selling book highlight
- Profit margin statistics
- Monthly growth indicator

The statistics are displayed in a responsive grid layout with individual cards for each metric.

Closes #1